### PR TITLE
Make rolling attributes configurable

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -238,7 +238,7 @@ If an attribute has a maximum value, then the `&+` command will cap the increase
 This is useful for attributes like HP where you want to quickly give characters health but do not want to heal them past their maximum value.
 
 If you want to exceed the maximum value anyway, you can use `&++` instead, and the max value will be ignored.
-Currently, `&--` is also supported but functions identically to `&-`
+Currently, `&--` is also supported but functions identically to `&-`.
 
 **Basic Example**:
 * `&+1 strength` - Add 1 to the strength attribute of the current user

--- a/Commands.md
+++ b/Commands.md
@@ -16,7 +16,9 @@ The `&roll` command allows you to roll any combination of the following expressi
     * Example: `2d6` rolls two 6-sided dice. `d20` rolls one 20-sided die.
 * **Fixed modifiers**, in the format `<n>` where `n` is any integer (note that floating point numbers have undefined behaviour)
     * Example: `5` rolls a constant 5 every time
-* **Character attributes**, in the format of `<attribute name>`, where `attribute name` is the number of sides on a single die.
+* **Character attributes**, in the format of `<attribute name>`, where `attribute name` is either:
+    * a fixed modifier (default), or
+    * the number of sides on a single die (edit server's config.yml file so that roll.rollAttribute = true)
   You can use aliases (if configured) instead of the full attribute name.  
   **Note**: If an attribute the first expression in the roll command, then a d20 will automatically be added.
 
@@ -48,12 +50,13 @@ Assumptions:
 * `Char1` and `Char2` has an attribute called `strength` (alias `str`) set to 5 and 3 respectively
 
 Examples:
-* `&roll strength` - Rolls d20 + d5. The d5 is based on `Char1` strength attribute of 5
-* `&r str` - Rolls d20 + d5. Alias for the command above
-* `&r str + 2` - Rolls d20 + d5 + 2. Adds a fixed bonus of 2
-* `&r strength char2` - Rolls d20 + d3. The d3 is based on `Char2` strength of 3. Note names are case-insensitive
-* `&r str + 2d4 + 1 char2` - Rolls d20 + d3 + two d4 + 1
-* `&r d10 + str + 2` - **Rolls d10 + d5 + 2.** When adding anything before the character's attribute, the default d20 is dropped
+* `&roll strength` - Rolls d20 + 5. The 5 is based on `Char1` strength attribute of 5
+  * With `roll.rollAttributes` enabled, rolls d20 + d5 instead
+* `&r str` - Rolls d20 + 5. Alias for the command above
+* `&r str + 2` - Rolls d20 + 5 + 2. Adds a fixed bonus of 2
+* `&r strength char2` - Rolls d20 + 3. The 3 is based on `Char2` strength of 3. Note names are case-insensitive
+* `&r str + 2d4 + 1 char2` - Rolls d20 + 3 + two d4 + 1
+* `&r d10 + str + 2` - **Rolls d10 + 5 + 2.** When adding anything before the character's attribute, the default d20 is dropped
 
 **Example With Temporary Modifier**
 
@@ -63,11 +66,12 @@ Assumptions:
 
 Example:  
 The following commands are ran sequentially. Note how commands 2 and 3 are added but have no effect on the sequence. 
-1. `&r agi` - Rolls d20 + d2 + 3. The +3 modifier from agility is added on top of the usual d20 and d2. The temporary modifier is decremented from 2 more rolls to just 1 more roll.
+1. `&r agi` - Rolls d20 + 2 + 3. The +3 modifier from agility is added on top of the usual d20 and d2. The temporary modifier is decremented from 2 more rolls to just 1 more roll.
+   * With `roll.rollAttributes` enabled, rolls d20 + d2 + 3 instead
 2. `&r` - _Rolls a d20, as usual. Has no effect on the temporary modifier because command does not include an `agi` expression_
 3. `&r agi char2` - _Rolls a d20 + d4, as usual. Has no effect on the temporary modifier because the temporary modifier belongs to `Char1` not `Char2`_
-4. `&r agi` - Rolls d20 + d2 + 3. Same as command 1, now the temporary modifier is decremented from 1 to 0 (i.e. it is removed)
-5. `&r agi` - Rolls d20 + d2. The +3 modifier is now removed so it has no effect.
+4. `&r agi` - Rolls d20 + 2 + 3. Same as command 1, now the temporary modifier is decremented from 1 to 0 (i.e. it is removed)
+5. `&r agi` - Rolls d20 + 2. The +3 modifier is now removed so it has no effect.
 
 
 ## Character Profile Commands

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.rlee.discordbots</groupId>
   <artifactId>RPBot</artifactId>
-  <version>0.4.1</version>
+  <version>0.5.0</version>
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.rlee.discordbots</groupId>
     <artifactId>RPBot</artifactId>
-    <version>0.4.1</version>
+    <version>0.5.0</version>
     <repositories>
         <repository>
             <id>jcenter</id>

--- a/src/main/java/com/rlee/discordbots/rpbot/MessageListener.java
+++ b/src/main/java/com/rlee/discordbots/rpbot/MessageListener.java
@@ -110,7 +110,7 @@ public class MessageListener extends ListenerAdapter {
 			break;
 		}
 		case "roll": case "r":
-			rollCalculator.compute(content.substring(args[COMMAND_ARG].length()), channel, message, true);
+			rollCalculator.compute(content.substring(args[COMMAND_ARG].length()), channel, message);
 			break;
 		
 		case "alias": case "multialias": {

--- a/src/main/java/com/rlee/discordbots/rpbot/dice/RollCalculator.java
+++ b/src/main/java/com/rlee/discordbots/rpbot/dice/RollCalculator.java
@@ -28,17 +28,17 @@ public class RollCalculator {
 	 * Note: This command is only supported when sent through a guild with a registered game
 	 * @param expression
 	 * @param channel
-	 * @param author
-	 * @param rollAttribute Set to true to roll a die for each attribute where the number of faces on die is the attribute value
+	 * @param message
 	 *
 	 * @author R Lee
 	 */
-	public void compute(String expression, MessageChannel channel, Message message, boolean rollAttribute) {
+	public void compute(String expression, MessageChannel channel, Message message) {
 		List<Integer> numbers = new LinkedList<>();
 		User author = message.getAuthor();
 		String sender = author.getAsMention();
 		boolean inGame = channel instanceof TextChannel;
-		
+		boolean rollAttribute = false; // By default, set rollAttribute to be false
+
 		if (!Util.isEmptyString(expression)) {
     		RPGame game = null;
     		CharProfile profile = null;
@@ -54,6 +54,8 @@ public class RollCalculator {
 
     		// FIXME: Refactor into a function
     		getProfile: if (inGame) {
+    			rollAttribute = game.getRollConfig().getRollAttribute();
+
     			ProfileRegistry profileRegistry = game.getProfileRegistry();
 
     			// Based on how JDA caches guild members, members need to be loaded directly from the message itself

--- a/src/main/java/com/rlee/discordbots/rpbot/dice/RollConfig.java
+++ b/src/main/java/com/rlee/discordbots/rpbot/dice/RollConfig.java
@@ -1,0 +1,57 @@
+package com.rlee.discordbots.rpbot.dice;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+/**
+ * A general class for holding configuration for rolling based per RPGame
+ */
+public class RollConfig {
+    private final String configFilePath;
+
+    private boolean rollAttribute;
+
+    /**
+     * Create a new RollConfig with default settings
+     * @param configFilePath
+     */
+    public RollConfig(String configFilePath) {
+        this.configFilePath = configFilePath;
+
+        rollAttribute = false;
+    }
+
+    public boolean getRollAttribute() {
+        return rollAttribute;
+    }
+
+    /**
+     * Read config from the config file's "roll" section
+     * @throws FileNotFoundException
+     */
+    public void readConfigFromFile() throws FileNotFoundException {
+        File configFile = new File(configFilePath);
+        ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
+
+        if (!configFile.exists()) {
+            throw new FileNotFoundException("Config file not found!"); // TODO ensure that a config file always exists
+        }
+
+        try {
+            ObjectNode node = (ObjectNode) yamlMapper.readTree(configFile).get("roll");
+            rollAttribute = yamlMapper.treeToValue(node.get("rollAttribute"), Boolean.class);
+        } catch (JsonProcessingException e) {
+            // TODO Send message notifying user
+            e.printStackTrace();
+        } catch (IOException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/rlee/discordbots/rpbot/game/GameFileManager.java
+++ b/src/main/java/com/rlee/discordbots/rpbot/game/GameFileManager.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 
+import com.rlee.discordbots.rpbot.dice.RollConfig;
 import com.rlee.discordbots.rpbot.map.RPMapConfig;
 import com.rlee.discordbots.rpbot.profile.CharProfile;
 import com.rlee.discordbots.rpbot.profile.ProfilePrinter;
@@ -22,6 +23,10 @@ public class GameFileManager {
 		this.game = game;
 		gameDirectoryPath = "games/" + game.getGuild().getId();
 		configFilePath = gameDirectoryPath + "/config.yml";
+	}
+
+	RollConfig createRollConfig() {
+		return new RollConfig(configFilePath);
 	}
 
 	RPMapConfig createMapConfig() {
@@ -60,9 +65,10 @@ public class GameFileManager {
 	 * Load configuration settings for the particular game
 	 */
 	void loadConfig() {
-		// Presently only maps have config
+		// Presently only roll and map have config
 		try {
 			// Read config data for map
+			game.getRollConfig().readConfigFromFile();
 			game.getMapConfig().readMapConfigFromFile();
 
 			//Read config data for aliases

--- a/src/main/java/com/rlee/discordbots/rpbot/game/RPGame.java
+++ b/src/main/java/com/rlee/discordbots/rpbot/game/RPGame.java
@@ -1,5 +1,6 @@
 package com.rlee.discordbots.rpbot.game;
 
+import com.rlee.discordbots.rpbot.dice.RollConfig;
 import com.rlee.discordbots.rpbot.map.RPMapConfig;
 import com.rlee.discordbots.rpbot.profile.CharProfile;
 import com.rlee.discordbots.rpbot.regitstry.AliasRegistry;
@@ -11,6 +12,7 @@ import net.dv8tion.jda.api.entities.Guild;
 public class RPGame {
 
 	private GameFileManager gameFileManager;
+	private RollConfig rollConfig;
 	private RPMapConfig mapConfig;
 
 	private GameRegistry gameRegistry;
@@ -31,6 +33,7 @@ public class RPGame {
 		aliasRegistry = new AliasRegistry(this);
 		mapRegistry = new MapRegistry(this);
 		gameFileManager = new GameFileManager(this);
+		rollConfig = gameFileManager.createRollConfig();
 		mapConfig = gameFileManager.createMapConfig();
 
 		gameFileManager.checkCreateFiles();
@@ -56,6 +59,10 @@ public class RPGame {
 
 	public MapRegistry getMapRegistry() {
 		return mapRegistry;
+	}
+
+	public RollConfig getRollConfig() {
+		return rollConfig;
 	}
 
 	public RPMapConfig getMapConfig() {

--- a/src/test/java/com/rlee/discordbots/rpbot/dice/RollCalculatorTest.java
+++ b/src/test/java/com/rlee/discordbots/rpbot/dice/RollCalculatorTest.java
@@ -5,11 +5,9 @@ import com.rlee.discordbots.rpbot.game.RPGame;
 import com.rlee.discordbots.rpbot.profile.CharProfile;
 import com.rlee.discordbots.rpbot.regitstry.AliasRegistry;
 import com.rlee.discordbots.rpbot.regitstry.ProfileRegistry;
-import com.sun.org.apache.bcel.internal.generic.RETURN;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
@@ -18,12 +16,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
@@ -40,6 +36,7 @@ public class RollCalculatorTest {
     @Mock private ThreadLocalRandom threadLocalRandom;
     @Mock private Guild guild;
     @Mock private RPGame game;
+    @Mock private RollConfig rollConfig;
     @Mock private AliasRegistry aliasRegistry;
     @Mock private ProfileRegistry profileRegistry;
     @Mock private CharProfile authorProfile;
@@ -82,7 +79,7 @@ public class RollCalculatorTest {
         mockPrinter(expectedOutput);
         try (MockedStatic<ThreadLocalRandom> threadLocalRandomClass = mockStatic(ThreadLocalRandom.class)) {
             threadLocalRandomClass.when(ThreadLocalRandom::current).thenReturn(threadLocalRandom);
-            rollCalculator.compute("", channel, message, true);
+            rollCalculator.compute("", channel, message);
         }
         verifyPrint(expectedOutput);
     }
@@ -90,6 +87,8 @@ public class RollCalculatorTest {
     @Test
     public void whenDiceGivenDiceUsed() {
         when(channel.getGuild()).thenReturn(guild);
+        when(game.getRollConfig()).thenReturn(rollConfig);
+        when(rollConfig.getRollAttribute()).thenReturn(false);
         when(game.getProfileRegistry()).thenReturn(profileRegistry);
         when(message.getMember()).thenReturn(authorMember);
         when(game.getAliasRegistry()).thenReturn(aliasRegistry);
@@ -105,7 +104,7 @@ public class RollCalculatorTest {
             threadLocalRandomClass.when(ThreadLocalRandom::current).thenReturn(threadLocalRandom);
             rpBot.when(() -> RPBot.getGame(guild)).thenReturn(game);
 
-            rollCalculator.compute(expression, channel, message, true);
+            rollCalculator.compute(expression, channel, message);
         }
         verifyPrint(expectedOutput);
     }


### PR DESCRIPTION
New config option required in game's `config.yml`:
```yml
roll:
  rollAttribute: false # Recommend to set to false
```
Assume the character the player has claimed has `str` set to `5`
This option sets the behaviour of `&r str` to roll d20 + 5 (previously fixed at d20 + d5)